### PR TITLE
[REFACTO]: remove all the throw's and replace them by std::optional &…

### DIFF
--- a/client/src/Client.cpp
+++ b/client/src/Client.cpp
@@ -27,18 +27,18 @@ void Client::loop()
   while (g_running) {
     NetworkPacket msg;
     while (m_networkManager->poll(msg)) {
-      std::string data = m_networkManager->getPacketHandler()->deserialize(msg.getData(), msg.getBytesTransferred());
-      std::cout << "Data: " << data << std::endl;
+      auto data = m_networkManager->getPacketHandler()->deserialize(msg.getData(), msg.getBytesTransferred());
+      if (!data.has_value()) {
+        std::cout << "Failed to deserialize incoming packet." << std::endl;
+        continue;
+      }
+      std::cout << "Data: " << data.value() << std::endl;
     }
     auto serialized = m_networkManager->getPacketHandler()->serialize("PING");
     m_networkManager->send(
       std::span<const std::byte>(reinterpret_cast<const std::byte *>(serialized.data()), serialized.size()), 0);
     std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
-  auto serialized = m_networkManager->getPacketHandler()->serialize("PING");
-  m_networkManager->send(
-    std::span<const std::byte>(reinterpret_cast<const std::byte *>(serialized.data()), serialized.size()), 0);
-  std::this_thread::sleep_for(std::chrono::milliseconds(16));
 }
 
 void Client::signalHandler(int signum)

--- a/network/include/CapnpHandler.hpp
+++ b/network/include/CapnpHandler.hpp
@@ -41,7 +41,8 @@ public:
    * @param bytesTransferred Number of bytes received
    * @return Deserialized message string
    */
-  std::string deserialize(const std::array<char, BUFFER_SIZE> &buffer, std::size_t bytesTransferred) const override;
+  std::optional<std::string> deserialize(const std::array<char, BUFFER_SIZE> &buffer,
+                                         std::size_t bytesTransferred) const override;
 
   /**
    * @brief Convert string to byte vector

--- a/network/include/IPacketHandler.hpp
+++ b/network/include/IPacketHandler.hpp
@@ -17,6 +17,7 @@
 #include <capnp/message.h>
 #include <capnp/serialize.h>
 #include <kj/std/iostream.h>
+#include <optional>
 
 /**
  * @brief Interface for packet serialization/deserialization
@@ -43,7 +44,8 @@ public:
    * @param bytesTransferred Number of bytes received
    * @return Deserialized message string
    */
-  virtual std::string deserialize(const std::array<char, BUFFER_SIZE> &buffer, std::size_t bytesTransferred) const = 0;
+  virtual std::optional<std::string> deserialize(const std::array<char, BUFFER_SIZE> &buffer,
+                                                 std::size_t bytesTransferred) const = 0;
 };
 
 #endif // I_PACKET_HANDLER_HPP_

--- a/network/src/CapnpHandler.cpp
+++ b/network/src/CapnpHandler.cpp
@@ -21,10 +21,11 @@ std::vector<std::uint8_t> CapnpHandler::serialize(const std::string &data) const
   return std::vector<std::uint8_t>(arr.begin(), arr.end());
 }
 
-std::string CapnpHandler::deserialize(const std::array<char, BUFFER_SIZE> &buffer, std::size_t bytesTransferred) const
+std::optional<std::string> CapnpHandler::deserialize(const std::array<char, BUFFER_SIZE> &buffer,
+                                                     std::size_t bytesTransferred) const
 {
   if (bytesTransferred == 0) {
-    throw std::runtime_error("Empty buffer received");
+    return std::nullopt;
   }
   kj::ArrayPtr<const kj::byte> bytes(reinterpret_cast<const kj::byte *>(buffer.data()), bytesTransferred);
   kj::ArrayInputStream stream(bytes);
@@ -35,7 +36,7 @@ std::string CapnpHandler::deserialize(const std::array<char, BUFFER_SIZE> &buffe
     auto type = netMsg.getMessageType();
     return std::string(type.cStr(), type.size());
   } catch (const kj::Exception &e) {
-    throw std::runtime_error(std::string("Cap'n Proto error: ") + e.getDescription().cStr());
+    return std::nullopt;
   }
 }
 

--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -30,8 +30,12 @@ void Server::loop()
   while (g_running) {
     NetworkPacket msg;
     if (m_networkManager->poll(msg)) {
-      std::string data = m_networkManager->getPacketHandler()->deserialize(msg.getData(), msg.getBytesTransferred());
-      std::cout << "Data: " << data << std::endl;
+      auto data = m_networkManager->getPacketHandler()->deserialize(msg.getData(), msg.getBytesTransferred());
+      if (!data.has_value()) {
+        std::cout << "Failed to deserialize incoming packet." << std::endl;
+        continue;
+      }
+      std::cout << "Data: " << data.value() << std::endl;
     }
     auto serialized = m_networkManager->getPacketHandler()->serialize("PONG");
     m_networkManager->send(


### PR DESCRIPTION
This pull request refactors packet deserialization to improve error handling and robustness in both client and server code. The main change is switching deserialization methods to return `std::optional<std::string>` instead of throwing exceptions, allowing the code to gracefully handle failed deserialization attempts. Additionally, the server-side receive buffer size is reduced, and minor code cleanups are made.

### Packet Deserialization Refactor

* Changed the `deserialize` method in both `IPacketHandler` and `CapnpHandler` from returning a `std::string` (with exception on error) to returning a `std::optional<std::string>`, so errors are handled without exceptions. The implementation now returns `std::nullopt` on failure or empty buffer. (`network/include/IPacketHandler.hpp`, `network/include/CapnpHandler.hpp`, `network/src/CapnpHandler.cpp`) [[1]](diffhunk://#diff-2cc22bcc12460c775cf73f1443a817ed0373c4168a1588f15ac03784d3181d68L44-R45) [[2]](diffhunk://#diff-ac62187fa04cbde3b8f52139e23a7d307481a326491eb681d591c73452f5e9d9L46-R48) [[3]](diffhunk://#diff-981a0441c60f69f332a9c600b22149f61eac1f1ee1e011e2550fad6219e78849L24-R28) [[4]](diffhunk://#diff-981a0441c60f69f332a9c600b22149f61eac1f1ee1e011e2550fad6219e78849L38-R39) [[5]](diffhunk://#diff-ac62187fa04cbde3b8f52139e23a7d307481a326491eb681d591c73452f5e9d9R20)
* Updated `Client::loop` and `Server::loop` to check for `has_value()` after deserialization and print an error message if deserialization fails, instead of crashing or proceeding with invalid data. (`client/src/Client.cpp`, `server/src/Server.cpp`) [[1]](diffhunk://#diff-49fc4f72c9bda2d1e64bb6bd59e0d26e895319333fcb45a32796d270163129c7L30-R42) [[2]](diffhunk://#diff-227723e0c7ab24fe587b39d405ce77b7e10bf0711b73f14da4dfbb5304b2a878L33-R38)

### Server Networking Updates

* Reduced the UDP receive buffer size in `AsioServer` from 16MB to 8MB, which may help optimize memory usage. (`network/src/AsioServer.cpp`)
* Minor cleanup in `AsioServer::start` loop iteration style for consistency. (`network/src/AsioServer.cpp`)
* Removed unnecessary try/catch block in `AsioServer::receive`, since deserialization errors are now handled via `std::optional` instead of exceptions. (`network/src/AsioServer.cpp`)